### PR TITLE
Changes that are relevant for the next version of IRAF

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-title: IRAF 2.16.1+
+title: IRAF 2.17
 ---
 
 [![ascl:9911.002](https://img.shields.io/badge/ascl-9911.002-blue.svg?colorB=262255)](http://ascl.net/9911.002)

--- a/install.md
+++ b/install.md
@@ -1,5 +1,5 @@
 ---
-title: IRAF 2.16.1+ Installation Instructions
+title: IRAF 2.17 Installation Instructions
 ---
 
 [![GitHub release](https://img.shields.io/github/release/iraf-community/iraf.svg)](https://github.com/iraf-community/iraf/releases/latest)
@@ -20,12 +20,9 @@ you want to help packaging for macOS or other Linux versions.
 
 ## Distribution Files
 
-The IRAF v2.16.1 snapshots are available from github at
+IRAF v2.17 is available from github at
 
 [https://github.com/iraf-community/iraf/releases/latest/](https://github.com/iraf-community/iraf/releases/latest/)
-
-The snapshot has the release date as a suffix in the version number
-and in the file name.
 
 
 ## System Requirements and Dependencies
@@ -56,8 +53,8 @@ The source distribution file is built as a tarball with the package
 name and version as base directory. Thus, distribution files can be
 unpacked with the command
 
-    $ tar zxf /<path>/iraf-2.16.1-2021.06.14.tar.gz
-    $ cd iraf-2.16.1-2021.06.14/
+    $ tar zxf /<path>/iraf-2.17.tar.gz
+    $ cd iraf-2.17/
 
 In the source directory, execute the install script to create needed
 links:

--- a/release.md
+++ b/release.md
@@ -1,19 +1,20 @@
 ---
-title: IRAF 2.16.1+ Release notes
+title: IRAF 2.17 Release notes
 ---
 
 [![GitHub release](https://img.shields.io/github/release/iraf-community/iraf.svg)](https://github.com/iraf-community/iraf/releases/latest)
 
 ## Release notes
 
-The current IRAF snapshot is available from github at
+The current IRAF version is available from github at
 
 [https://github.com/iraf-community/iraf/releases/latest/](https://github.com/iraf-community/iraf/releases/latest/)
 
-The latest official IRAF release is 2.16.1 from October 2013. Our releases are
-snapshots based on that latest available source code. The snapshots are tagged
-with their release date in the version number. Changes to the original 2.16.1
-sources include:
+The latest official IRAF release was 2.16.1 from October
+2013. Intermediate releases were snapshots based on that latest
+available source code. These snapshots were tagged with their release
+date in the version number. Changes to the original 2.16.1 sources
+include:
 
 * __All known non-free code removed__
 

--- a/release.md
+++ b/release.md
@@ -76,6 +76,26 @@ include:
 
 This list shows all pull requests that were merged since 2.16.1.
 
+### Since 2.14.1+2021.06.14
+
+* Consistently format doc/help examples
+  ([#195](https://github.com/iraf-community/iraf/pull/195))
+* Fix some HTML help output glitches
+  ([#194](https://github.com/iraf-community/iraf/pull/194))
+* Remove duplicate argument in call
+  ([#189](https://github.com/iraf-community/iraf/pull/189))
+* Revert corruption of unix/os/net/rexec.c file
+  ([#180](https://github.com/iraf-community/iraf/pull/180))
+* Force using POSIX shell in extpkg.cl script
+  ([#179](https://github.com/iraf-community/iraf/pull/179))
+* Support freeBSD variants
+  ([#174](https://github.com/iraf-community/iraf/pull/174))
+* Separate development (softools) packages
+  ([#172](https://github.com/iraf-community/iraf/pull/172))
+* Remove obsolete tasks and links to iraf.noao.edu
+  ([#170](https://github.com/iraf-community/iraf/pull/170))
+
+
 ### Since 2.16.1+2018.11.01
 
  * Cleanup for unneeded and obsolete files
@@ -94,7 +114,8 @@ This list shows all pull requests that were merged since 2.16.1.
    ([#126](https://github.com/iraf-community/iraf/pull/126))
  * Fix cpu_time calculation in unix/os/zgtime.c
    ([#118](https://github.com/iraf-community/iraf/pull/118),
-    [#136](https://github.com/iraf-community/iraf/pull/136))
+    [#136](https://github.com/iraf-community/iraf/pull/136),
+    [#173](https://github.com/iraf-community/iraf/pull/173))
  * Move zsvjmp assembler files to unix/os and merge them
    ([#117](https://github.com/iraf-community/iraf/pull/117))
  * Use PLT when calling sigsetjmp on i386
@@ -106,7 +127,8 @@ This list shows all pull requests that were merged since 2.16.1.
  * Avoid multiple definition of `errflag`
    ([#111](https://github.com/iraf-community/iraf/pull/111))
  * Enable the use of Public Domain Ratfor to process `.r` files
-   ([#103](https://github.com/iraf-community/iraf/pull/103))
+   ([#103](https://github.com/iraf-community/iraf/pull/103),
+    [#171](https://github.com/iraf-community/iraf/pull/171))
  * Remove some C compiler warnings
    ([#97](https://github.com/iraf-community/iraf/pull/97))
  * Fix non-working fft841 code by replacing it


### PR DESCRIPTION
* Switch back to conventional version numbers for IRAF